### PR TITLE
Bump version compat to 2023.3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ repositories {
 
 // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {
-    version.set("2023.1")
+    version.set("2023.3")
     type.set("IC") // Target IDE Platform
 
     plugins.set(listOf(/* Plugin Dependencies */))


### PR DESCRIPTION
I have installed this change to my local IntelliJ, and it looks just as before to me.

Though I have not done any plugin development at all, so there may be something that I have missed.

But since this is only a patch bump in compatibility version I'm guessing this should be fine.
