### PR TITLE
Allow using this theme in 253-series IDE builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 pluginSinceBuild = 231
-pluginUntilBuild = 252.*
+pluginUntilBuild = 253.*
 platformType = IC
-platformVersion = 2024.2
+platformVersion = 2024.3


### PR DESCRIPTION
## Summary
- allow installing the theme on all 253.* IDE builds by raising the until-build range
- keep building against the 2024.3 platform SDK as a stable baseline

## Testing
- gradlew buildPlugin and verified on Rider 2025.3.0.3.
